### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,10 +16,9 @@ jobs:
           submodules: 'recursive'
 
       - name: Setup Typst
-        uses: yusancky/setup-typst@v2.0.1
-        id: setup-typst
+        uses: typst-community/setup-typst@v4
         with:
-          version: 'latest'
+          typst-version: 'latest'
 
       - run: typst compile cv.typ --font-path ./src/fonts
 


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.